### PR TITLE
Frontend: MUI Theme for Create Model Registry Form

### DIFF
--- a/.github/workflows/build-image-ui-pr.yml
+++ b/.github/workflows/build-image-ui-pr.yml
@@ -1,0 +1,25 @@
+name: Test UI container image build and deployment
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "clients/ui/**"
+      - "!LICENSE*"
+      - "!DOCKERFILE*"
+      - "!**.gitignore"
+      - "!**.md"
+      - "!**.txt"
+env:
+  IMG_ORG: kubeflow
+  IMG_REPO: model-registry-ui
+  PUSH_IMAGE: false
+  BRANCH: ${{ github.base_ref }}
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout branch
+      - uses: actions/checkout@v4
+      - name: Build UI Image
+        shell: bash
+        run: ./scripts/build_deploy.sh

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTable.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistriesTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { ModelRegistry } from '~/app/types';
 import { Table } from '~/shared/components/table';
 import { modelRegistryColumns } from './columns';
@@ -6,14 +7,33 @@ import ModelRegistriesTableRow from './ModelRegistriesTableRow';
 
 type ModelRegistriesTableProps = {
   modelRegistries: ModelRegistry[];
+  onCreateModelRegistryClick: () => void;
 };
 
-const ModelRegistriesTable: React.FC<ModelRegistriesTableProps> = ({ modelRegistries }) => (
+const ModelRegistriesTable: React.FC<ModelRegistriesTableProps> = ({
+  modelRegistries,
+  onCreateModelRegistryClick,
+}) => (
   // TODO: [Midstream] Complete once we have permissions
   <Table
     data-testid="model-registries-table"
     data={modelRegistries}
     columns={modelRegistryColumns}
+    toolbarContent={
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            <Button
+              data-testid="create-model-registry-button"
+              variant="primary"
+              onClick={onCreateModelRegistryClick}
+            >
+              Create model registry
+            </Button>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+    }
     rowRenderer={(mr) => (
       <ModelRegistriesTableRow
         key={mr.name}

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
@@ -1,0 +1,248 @@
+import * as React from 'react';
+import {
+  Button,
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+import { Modal } from '@patternfly/react-core/deprecated';
+import { useNavigate } from 'react-router';
+import ModelRegistryCreateModalFooter from '~/app/pages/settings/ModelRegistryCreateModalFooter';
+import FormSection from '~/shared/components/pf-overrides/FormSection';
+
+import ModelRegistryDatabasePassword from '~/app/pages/settings/ModelRegistryDatabasePassword';
+import K8sNameDescriptionField from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+
+type CreateModalProps = {
+  onClose: () => void;
+  // refresh: () => Promise<unknown>;
+  // modelRegistry: ModelRegistry;
+};
+
+const CreateModal: React.FC<CreateModalProps> = ({
+  onClose,
+  // refresh,
+  // modelRegistry,
+}) => {
+  const [error, setError] = React.useState<Error>();
+
+  const [host, setHost] = React.useState('');
+  const [port, setPort] = React.useState('');
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [database, setDatabase] = React.useState('');
+  //   const [addSecureDB, setAddSecureDB] = React.useState(false);
+  const [isHostTouched, setIsHostTouched] = React.useState(false);
+  const [isPortTouched, setIsPortTouched] = React.useState(false);
+  const [isUsernameTouched, setIsUsernameTouched] = React.useState(false);
+  const [isPasswordTouched, setIsPasswordTouched] = React.useState(false);
+  const [isDatabaseTouched, setIsDatabaseTouched] = React.useState(false);
+  const [showPassword, setShowPassword] = React.useState(false);
+
+  const navigate = useNavigate();
+
+  const onBeforeClose = () => {
+    // setIsSubmitting(false);
+    setError(undefined);
+
+    setHost('');
+    setPort('');
+    setUsername('');
+    setPassword('');
+    setDatabase('');
+    setIsHostTouched(false);
+    setIsPortTouched(false);
+    setIsUsernameTouched(false);
+    setIsPasswordTouched(false);
+    setIsDatabaseTouched(false);
+    setShowPassword(false);
+    onClose();
+  };
+
+  const hasContent = (value: string): boolean => !!value.trim().length;
+
+  const canSubmit = () =>
+    // TODO: implement once we have the endpoint
+    // !isSubmitting &&
+    // isValidK8sName(nameDesc.k8sName.value || translateDisplayNameForK8s(nameDesc.name))
+    // &&
+    hasContent(host) &&
+    hasContent(password) &&
+    hasContent(port) &&
+    hasContent(username) &&
+    hasContent(database);
+  // &&
+  // (!addSecureDB || (secureDBInfo.isValid && !configSecretsError))
+
+  const onSubmit = () => {
+    navigate(`/model-registry-settings`);
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen
+      title="Create model registry"
+      onClose={onBeforeClose}
+      actions={[
+        <Button key="create-button" variant="primary" isDisabled={!canSubmit()} onClick={onSubmit}>
+          Create
+        </Button>,
+        <Button key="cancel-button" variant="secondary" onClick={onBeforeClose}>
+          Cancel
+        </Button>,
+      ]}
+      variant="medium"
+      footer={
+        <ModelRegistryCreateModalFooter
+          onCancel={onBeforeClose}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+          // isSubmitLoading={isSubmitting}
+          isSubmitDisabled={!canSubmit()}
+          error={error}
+          alertTitle={`Error ${'creating'} model registry`}
+        />
+      }
+    >
+      <Form>
+        <K8sNameDescriptionField
+          dataTestId="mr"
+          // data={nameDesc}
+          //  onDataChange={setNameDesc}
+        />
+        <FormSection
+          title="Connect to external MySQL database"
+          description="This external database is where model data is stored."
+        >
+          <FormGroup label="Host" isRequired fieldId="mr-host">
+            <TextInput
+              isRequired
+              type="text"
+              id="mr-host"
+              name="mr-host"
+              value={host}
+              onBlur={() => setIsHostTouched(true)}
+              onChange={(_e, value) => setHost(value)}
+              validated={isHostTouched && !hasContent(host) ? 'error' : 'default'}
+            />
+            {isHostTouched && !hasContent(host) && (
+              <HelperText>
+                <HelperTextItem variant="error" data-testid="mr-host-error">
+                  Host cannot be empty
+                </HelperTextItem>
+              </HelperText>
+            )}
+          </FormGroup>
+          <FormGroup label="Port" isRequired fieldId="mr-port">
+            <TextInput
+              isRequired
+              type="text"
+              id="mr-port"
+              name="mr-port"
+              value={port}
+              onBlur={() => setIsPortTouched(true)}
+              onChange={(_e, value) => setPort(value)}
+              validated={isPortTouched && !hasContent(port) ? 'error' : 'default'}
+            />
+            {isPortTouched && !hasContent(port) && (
+              <HelperText>
+                <HelperTextItem variant="error" data-testid="mr-port-error">
+                  Port cannot be empty
+                </HelperTextItem>
+              </HelperText>
+            )}
+          </FormGroup>
+          <FormGroup label="Username" isRequired fieldId="mr-username">
+            <TextInput
+              isRequired
+              type="text"
+              id="mr-username"
+              name="mr-username"
+              value={username}
+              onBlur={() => setIsUsernameTouched(true)}
+              onChange={(_e, value) => setUsername(value)}
+              validated={isUsernameTouched && !hasContent(username) ? 'error' : 'default'}
+            />
+            {isUsernameTouched && !hasContent(username) && (
+              <HelperText>
+                <HelperTextItem variant="error" data-testid="mr-username-error">
+                  Username cannot be empty
+                </HelperTextItem>
+              </HelperText>
+            )}
+          </FormGroup>
+          <FormGroup label="Password" isRequired fieldId="mr-password">
+            <ModelRegistryDatabasePassword
+              password={password || ''}
+              setPassword={setPassword}
+              isPasswordTouched={isPasswordTouched}
+              setIsPasswordTouched={setIsPasswordTouched}
+              showPassword={showPassword}
+              //   editRegistry={mr}
+            />
+          </FormGroup>
+          <FormGroup label="Database" isRequired fieldId="mr-database">
+            <TextInput
+              isRequired
+              type="text"
+              id="mr-database"
+              name="mr-database"
+              value={database}
+              onBlur={() => setIsDatabaseTouched(true)}
+              onChange={(_e, value) => setDatabase(value)}
+              validated={isDatabaseTouched && !hasContent(database) ? 'error' : 'default'}
+            />
+            {isDatabaseTouched && !hasContent(database) && (
+              <HelperText>
+                <HelperTextItem variant="error" data-testid="mr-database-error">
+                  Database cannot be empty
+                </HelperTextItem>
+              </HelperText>
+            )}
+          </FormGroup>
+          {/* {secureDbEnabled && (
+            <>
+              <FormGroup>
+                <Checkbox
+                  label="Add CA certificate to secure database connection"
+                  isChecked={addSecureDB}
+                  onChange={(_e, value) => setAddSecureDB(value)}
+                  id="add-secure-db"
+                  data-testid="add-secure-db-mr-checkbox"
+                  name="add-secure-db"
+                />
+              </FormGroup>
+              {addSecureDB &&
+                (!configSecretsLoaded && !configSecretsError ? (
+                  <EmptyState icon={Spinner} />
+                ) : configSecretsLoaded ? (
+                  <CreateMRSecureDBSection
+                    secureDBInfo={secureDBInfo}
+                    modelRegistryNamespace={modelRegistryNamespace}
+                    k8sName={nameDesc.k8sName.value}
+                    existingCertConfigMaps={configSecrets.configMaps}
+                    existingCertSecrets={configSecrets.secrets}
+                    setSecureDBInfo={setSecureDBInfo}
+                  />
+                ) : (
+                  <Alert
+                    isInline
+                    variant="danger"
+                    title="Error fetching config maps and secrets"
+                    data-testid="error-fetching-resource-alert"
+                  >
+                    {configSecretsError?.message}
+                  </Alert>
+                ))}
+            </>
+          )} */}
+        </FormSection>
+      </Form>
+    </Modal>
+  );
+};
+
+export default CreateModal;

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModal.tsx
@@ -10,10 +10,12 @@ import {
 import { Modal } from '@patternfly/react-core/deprecated';
 import { useNavigate } from 'react-router';
 import ModelRegistryCreateModalFooter from '~/app/pages/settings/ModelRegistryCreateModalFooter';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import FormSection from '~/shared/components/pf-overrides/FormSection';
 
 import ModelRegistryDatabasePassword from '~/app/pages/settings/ModelRegistryDatabasePassword';
 import K8sNameDescriptionField from '~/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField';
+import { isMUITheme } from '~/shared/utilities/const';
 
 type CreateModalProps = {
   onClose: () => void;
@@ -81,6 +83,179 @@ const CreateModal: React.FC<CreateModalProps> = ({
     onClose();
   };
 
+  const hostInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-host"
+      name="mr-host"
+      value={host}
+      onBlur={() => setIsHostTouched(true)}
+      onChange={(_e, value) => setHost(value)}
+      validated={isHostTouched && !hasContent(host) ? 'error' : 'default'}
+    />
+  );
+
+  const hostHelperText = isHostTouched && !hasContent(host) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-host-error">
+        Host cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const hostFormGroup = (
+    <>
+      <FormGroup
+        className={hostHelperText ? 'pf-m-error' : ''}
+        label="Host"
+        isRequired
+        fieldId="mr-host"
+      >
+        <FormFieldset component={hostInput} field="Host" />
+      </FormGroup>
+      {hostHelperText}
+    </>
+  );
+
+  const portInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-port"
+      name="mr-port"
+      value={port}
+      onBlur={() => setIsPortTouched(true)}
+      onChange={(_e, value) => setPort(value)}
+      validated={isPortTouched && !hasContent(port) ? 'error' : 'default'}
+    />
+  );
+
+  const portHelperText = isPortTouched && !hasContent(port) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-port-error">
+        Port cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const portFormGroup = (
+    <>
+      <FormGroup
+        className={portHelperText ? 'pf-m-error' : ''}
+        label="Port"
+        isRequired
+        fieldId="mr-port"
+      >
+        <FormFieldset component={portInput} field="Port" />
+      </FormGroup>
+      {portHelperText}
+    </>
+  );
+
+  const userNameInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-username"
+      name="mr-username"
+      value={username}
+      onBlur={() => setIsUsernameTouched(true)}
+      onChange={(_e, value) => setUsername(value)}
+      validated={isUsernameTouched && !hasContent(username) ? 'error' : 'default'}
+    />
+  );
+
+  const usernameHelperText = isUsernameTouched && !hasContent(username) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-username-error">
+        Username cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const usernameFormGroup = (
+    <>
+      <FormGroup
+        className={usernameHelperText ? 'pf-m-error' : ''}
+        label="Username"
+        isRequired
+        fieldId="mr-username"
+      >
+        <FormFieldset component={userNameInput} field="Host" />
+      </FormGroup>
+      {usernameHelperText}
+    </>
+  );
+
+  const passwordInput = (
+    <ModelRegistryDatabasePassword
+      password={password || ''}
+      setPassword={setPassword}
+      isPasswordTouched={isPasswordTouched}
+      setIsPasswordTouched={setIsPasswordTouched}
+      showPassword={showPassword}
+      //   editRegistry={mr}
+    />
+  );
+
+  const passwordHelperText = isPasswordTouched && !hasContent(password) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-password-error">
+        Password cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const passwordFormGroup = (
+    <>
+      <FormGroup
+        className={passwordHelperText ? 'pf-m-error' : ''}
+        label="Password"
+        isRequired
+        fieldId="mr-password"
+      >
+        <FormFieldset component={passwordInput} field="Password" />
+      </FormGroup>
+      {passwordHelperText}
+    </>
+  );
+
+  const databaseInput = (
+    <TextInput
+      isRequired
+      type="text"
+      id="mr-database"
+      name="mr-database"
+      value={database}
+      onBlur={() => setIsDatabaseTouched(true)}
+      onChange={(_e, value) => setDatabase(value)}
+      validated={isDatabaseTouched && !hasContent(database) ? 'error' : 'default'}
+    />
+  );
+
+  const databaseHelperText = isDatabaseTouched && !hasContent(database) && (
+    <HelperText>
+      <HelperTextItem variant="error" data-testid="mr-database-error">
+        Database cannot be empty
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  const databaseFormGroup = (
+    <>
+      <FormGroup
+        className={databaseHelperText ? 'pf-m-error' : ''}
+        label="Database"
+        isRequired
+        fieldId="mr-database"
+      >
+        <FormFieldset component={databaseInput} field="Database" />
+      </FormGroup>
+      {databaseHelperText}
+    </>
+  );
+
   return (
     <Modal
       isOpen
@@ -117,92 +292,56 @@ const CreateModal: React.FC<CreateModalProps> = ({
           title="Connect to external MySQL database"
           description="This external database is where model data is stored."
         >
-          <FormGroup label="Host" isRequired fieldId="mr-host">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-host"
-              name="mr-host"
-              value={host}
-              onBlur={() => setIsHostTouched(true)}
-              onChange={(_e, value) => setHost(value)}
-              validated={isHostTouched && !hasContent(host) ? 'error' : 'default'}
-            />
-            {isHostTouched && !hasContent(host) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-host-error">
-                  Host cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Port" isRequired fieldId="mr-port">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-port"
-              name="mr-port"
-              value={port}
-              onBlur={() => setIsPortTouched(true)}
-              onChange={(_e, value) => setPort(value)}
-              validated={isPortTouched && !hasContent(port) ? 'error' : 'default'}
-            />
-            {isPortTouched && !hasContent(port) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-port-error">
-                  Port cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Username" isRequired fieldId="mr-username">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-username"
-              name="mr-username"
-              value={username}
-              onBlur={() => setIsUsernameTouched(true)}
-              onChange={(_e, value) => setUsername(value)}
-              validated={isUsernameTouched && !hasContent(username) ? 'error' : 'default'}
-            />
-            {isUsernameTouched && !hasContent(username) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-username-error">
-                  Username cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
-          <FormGroup label="Password" isRequired fieldId="mr-password">
-            <ModelRegistryDatabasePassword
-              password={password || ''}
-              setPassword={setPassword}
-              isPasswordTouched={isPasswordTouched}
-              setIsPasswordTouched={setIsPasswordTouched}
-              showPassword={showPassword}
-              //   editRegistry={mr}
-            />
-          </FormGroup>
-          <FormGroup label="Database" isRequired fieldId="mr-database">
-            <TextInput
-              isRequired
-              type="text"
-              id="mr-database"
-              name="mr-database"
-              value={database}
-              onBlur={() => setIsDatabaseTouched(true)}
-              onChange={(_e, value) => setDatabase(value)}
-              validated={isDatabaseTouched && !hasContent(database) ? 'error' : 'default'}
-            />
-            {isDatabaseTouched && !hasContent(database) && (
-              <HelperText>
-                <HelperTextItem variant="error" data-testid="mr-database-error">
-                  Database cannot be empty
-                </HelperTextItem>
-              </HelperText>
-            )}
-          </FormGroup>
+          {isMUITheme() ? (
+            hostFormGroup
+          ) : (
+            <>
+              <FormGroup label="Host" isRequired fieldId="mr-host">
+                {hostInput}
+                {hostHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            portFormGroup
+          ) : (
+            <>
+              <FormGroup label="Port" isRequired fieldId="mr-port">
+                {portInput}
+                {portHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            usernameFormGroup
+          ) : (
+            <>
+              <FormGroup label="Username" isRequired fieldId="mr-username">
+                {userNameInput}
+                {usernameHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            passwordFormGroup
+          ) : (
+            <>
+              <FormGroup label="Password" isRequired fieldId="mr-password">
+                {passwordInput}
+                {passwordHelperText}
+              </FormGroup>
+            </>
+          )}
+          {isMUITheme() ? (
+            databaseFormGroup
+          ) : (
+            <>
+              <FormGroup label="Database" isRequired fieldId="mr-database">
+                {databaseInput}
+                {databaseFormGroup}
+              </FormGroup>
+            </>
+          )}
           {/* {secureDbEnabled && (
             <>
               <FormGroup>

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModalFooter.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryCreateModalFooter.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import {
+  ActionList,
+  ActionListItem,
+  ActionListGroup,
+  Alert,
+  Button,
+  ButtonProps,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+
+type ModelRegistryCreateModalFooterProps = {
+  submitLabel: string;
+  submitButtonVariant?: ButtonProps['variant'];
+  onSubmit: () => void;
+  onCancel: () => void;
+  isSubmitDisabled?: boolean;
+  isSubmitLoading?: boolean;
+  isCancelDisabled?: boolean;
+  alertTitle?: string;
+  error?: Error;
+  alertLinks?: React.ReactNode;
+};
+
+const ModelRegistryCreateModalFooter: React.FC<ModelRegistryCreateModalFooterProps> = ({
+  submitLabel,
+  submitButtonVariant = 'primary',
+  onSubmit,
+  onCancel,
+  isSubmitDisabled,
+  isSubmitLoading,
+  isCancelDisabled,
+  error,
+  alertTitle,
+  alertLinks,
+}) => (
+  // make sure alert uses the full width
+  <Stack hasGutter style={{ flex: 'auto' }}>
+    {error && (
+      <StackItem>
+        <Alert
+          data-testid="error-message-alert"
+          isInline
+          variant="danger"
+          title={alertTitle}
+          actionLinks={alertLinks}
+        >
+          {error.message}
+        </Alert>
+      </StackItem>
+    )}
+    <StackItem>
+      <ActionList>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button
+              key="submit"
+              variant={submitButtonVariant}
+              isDisabled={isSubmitDisabled}
+              onClick={onSubmit}
+              isLoading={isSubmitLoading}
+              data-testid="modal-submit-button"
+            >
+              {submitLabel}
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button
+              key="cancel"
+              variant="link"
+              isDisabled={isCancelDisabled}
+              onClick={onCancel}
+              data-testid="modal-cancel-button"
+            >
+              Cancel
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
+      </ActionList>
+    </StackItem>
+  </Stack>
+);
+
+export default ModelRegistryCreateModalFooter;

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import PasswordInput from '~/app/pages/settings/PasswordInput';
+
+type ModelRegistryDatabasePasswordProps = {
+  password: string | undefined;
+  setPassword: (value: string) => void;
+  showPassword?: boolean;
+  isPasswordTouched?: boolean;
+  setIsPasswordTouched: (value: boolean) => void;
+  // editRegistry?: ModelRegistryKind;
+};
+
+const ModelRegistryDatabasePassword: React.FC<ModelRegistryDatabasePasswordProps> = ({
+  password = '',
+  setPassword,
+  showPassword,
+  isPasswordTouched,
+  setIsPasswordTouched,
+  // editRegistry: mr,
+}) => {
+  // TODO: Implement this
+  // const [existingDbPassword, passwordLoaded, passwordLoadError] = useFetchState(
+  //   React.useCallback<FetchStateCallbackPromise<string | undefined>>(async () => {
+  //     if (!mr) {
+  //       return Promise.reject(new NotReadyError('Model registry does not exist'));
+  //     }
+
+  //     const { databasePassword } = await getModelRegistryBackend(mr.metadata.name);
+  //     return databasePassword;
+  //   }, [mr]),
+  //   undefined,
+  // );
+
+  // React.useEffect(() => {
+  //   if (existingDbPassword && mr) {
+  //     setPassword(existingDbPassword);
+  //   }
+  // }, [existingDbPassword, setPassword, mr]);
+
+  const hasContent = (value: string): boolean => !!value.trim().length;
+
+  // if (!passwordLoaded && !passwordLoadError && mr) {
+  //   return <Skeleton screenreaderText="Loading contents" />;
+  // }
+
+  // if (passwordLoadError) {
+  //   return (
+  //     <Alert
+  //       variant="danger"
+  //       isInline
+  //       isPlain
+  //       title="Failed to load the password. The Secret file is missing."
+  //     />
+  //   );
+  // }
+
+  return (
+    <>
+      <PasswordInput
+        isRequired
+        type={showPassword ? 'text' : 'password'}
+        id="mr-password"
+        name="mr-password"
+        value={password}
+        onBlur={() => setIsPasswordTouched(true)}
+        onChange={(_e, value) => setPassword(value)}
+        validated={isPasswordTouched && !hasContent(password) ? 'error' : 'default'}
+      />
+      {isPasswordTouched && !hasContent(password) && (
+        <HelperText>
+          <HelperTextItem variant="error" data-testid="mr-password-error">
+            Password cannot be empty
+          </HelperTextItem>
+        </HelperText>
+      )}
+    </>
+  );
+};
+
+export default ModelRegistryDatabasePassword;

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistryDatabasePassword.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import PasswordInput from '~/app/pages/settings/PasswordInput';
 
 type ModelRegistryDatabasePasswordProps = {
@@ -67,13 +66,6 @@ const ModelRegistryDatabasePassword: React.FC<ModelRegistryDatabasePasswordProps
         onChange={(_e, value) => setPassword(value)}
         validated={isPasswordTouched && !hasContent(password) ? 'error' : 'default'}
       />
-      {isPasswordTouched && !hasContent(password) && (
-        <HelperText>
-          <HelperTextItem variant="error" data-testid="mr-password-error">
-            Password cannot be empty
-          </HelperTextItem>
-        </HelperText>
-      )}
     </>
   );
 };

--- a/clients/ui/frontend/src/app/pages/settings/ModelRegistrySettings.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/ModelRegistrySettings.tsx
@@ -7,13 +7,28 @@ import useQueryParamNamespaces from '~/shared/hooks/useQueryParamNamespaces';
 import { isMUITheme } from '~/shared/utilities/const';
 import TitleWithIcon from '~/shared/components/design/TitleWithIcon';
 import { ProjectObjectType } from '~/shared/components/design/utils';
+// import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import ModelRegistriesTable from './ModelRegistriesTable';
+import CreateModal from './ModelRegistryCreateModal';
 
 const ModelRegistrySettings: React.FC = () => {
   const queryParams = useQueryParamNamespaces();
-  const [modelRegistries, mrloaded, loadError] = useModelRegistries(queryParams);
+  const [
+    modelRegistries,
+    mrloaded,
+    loadError,
+    // refreshModelRegistries
+  ] = useModelRegistries(queryParams);
+  const [createModalOpen, setCreateModalOpen] = React.useState(false);
   // TODO: [Midstream] Implement this when adding logic for rules review
+  // const { refreshRulesReview } = React.useContext(ModelRegistrySelectorContext);
+
   const loaded = mrloaded; //&& roleBindings.loaded;
+
+  // const refreshAll = React.useCallback(
+  //   () => Promise.all([refreshModelRegistries(), refreshRulesReview()]),
+  //   [refreshModelRegistries, refreshRulesReview],
+  // );
 
   return (
     <>
@@ -54,8 +69,19 @@ const ModelRegistrySettings: React.FC = () => {
         }
         provideChildrenPadding
       >
-        <ModelRegistriesTable modelRegistries={modelRegistries} />
+        <ModelRegistriesTable
+          modelRegistries={modelRegistries}
+          onCreateModelRegistryClick={() => {
+            setCreateModalOpen(true);
+          }}
+        />
       </ApplicationsPage>
+      {createModalOpen ? (
+        <CreateModal
+          onClose={() => setCreateModalOpen(false)}
+          // refresh={refreshAll}
+        />
+      ) : null}
     </>
   );
 };

--- a/clients/ui/frontend/src/app/pages/settings/PasswordInput.tsx
+++ b/clients/ui/frontend/src/app/pages/settings/PasswordInput.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Button, InputGroup, TextInput, InputGroupItem } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+
+type Props = React.ComponentProps<typeof TextInput> & {
+  ariaLabelShow?: string;
+  ariaLabelHide?: string;
+};
+
+const PasswordInput: React.FC<Props> = ({
+  ariaLabelShow = 'Show password',
+  ariaLabelHide = 'Hide password',
+  ...props
+}) => {
+  const [isPasswordHidden, setPasswordHidden] = React.useState(true);
+
+  return (
+    <InputGroup>
+      <InputGroupItem isFill>
+        <TextInput {...props} type={isPasswordHidden ? 'password' : 'text'} />
+      </InputGroupItem>
+      <InputGroupItem>
+        <Button
+          aria-label={isPasswordHidden ? ariaLabelShow : ariaLabelHide}
+          variant="control"
+          onClick={() => setPasswordHidden(!isPasswordHidden)}
+        >
+          {isPasswordHidden ? <EyeSlashIcon /> : <EyeIcon />}
+        </Button>
+      </InputGroupItem>
+    </InputGroup>
+  );
+};
+
+export default PasswordInput;

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import {
+  Button,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core';
+import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+import ResourceNameField from './ResourceNameField';
+
+// TODO: replace with the actual call once we have the endpoint
+
+/** Companion data hook */
+// export const useK8sNameDescriptionFieldData = (
+//   configuration: UseK8sNameDescriptionDataConfiguration = {},
+// ): UseK8sNameDescriptionFieldData => {
+//   const [data, setData] = React.useState<K8sNameDescriptionFieldData>(() =>
+//     setupDefaults(configuration),
+//   );
+
+//   const onDataChange = React.useCallback<K8sNameDescriptionFieldUpdateFunction>((key, value) => {
+//     setData((currentData) => handleUpdateLogic(currentData)(key, value));
+//   }, []);
+
+//   return { data, onDataChange };
+// };
+
+type K8sNameDescriptionFieldProps = {
+  autoFocusName?: boolean;
+  //   data: UseK8sNameDescriptionFieldData['data'];
+  dataTestId: string;
+  descriptionLabel?: string;
+  nameLabel?: string;
+  nameHelperText?: React.ReactNode;
+  //   onDataChange?: UseK8sNameDescriptionFieldData['onDataChange'];
+  hideDescription?: boolean;
+};
+
+/**
+ * Use in place of any K8s Resource creation / edit.
+ * @see useK8sNameDescriptionFieldData
+ */
+const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
+  autoFocusName,
+  //   data,
+  dataTestId,
+  descriptionLabel = 'Description',
+  //   onDataChange,
+  nameLabel = 'Name',
+  nameHelperText,
+  hideDescription,
+}) => {
+  const [showK8sField, setShowK8sField] = React.useState(false);
+
+  //   const { name, description, k8sName } = data;
+
+  return (
+    <>
+      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+        <TextInput
+          //   aria-readonly={!onDataChange}
+          data-testid={`${dataTestId}-name`}
+          id={`${dataTestId}-name`}
+          name={`${dataTestId}-name`}
+          autoFocus={autoFocusName}
+          isRequired
+          //   value={name}
+          //   onChange={(event, value) => onDataChange?.('name', value)}
+        />
+        {nameHelperText || !showK8sField ? (
+          //  &&
+          // !k8sName.state.immutable
+          <HelperText>
+            {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
+            {!showK8sField && (
+              // !k8sName.state.immutable
+              // &&
+              <>
+                {/* {k8sName.value && (
+                  <HelperTextItem>
+                    The resource name will be <b>{k8sName.value}</b>.
+                  </HelperTextItem>
+                )} */}
+                <HelperTextItem>
+                  <Button
+                    data-testid={`${dataTestId}-editResourceLink`}
+                    variant="link"
+                    isInline
+                    onClick={() => setShowK8sField(true)}
+                  >
+                    Edit resource name
+                  </Button>{' '}
+                  <ResourceNameDefinitionTooltip />
+                </HelperTextItem>
+              </>
+            )}
+          </HelperText>
+        ) : null}
+      </FormGroup>
+      <ResourceNameField
+        allowEdit={showK8sField}
+        dataTestId={dataTestId}
+        // k8sName={k8sName}
+        // onDataChange={onDataChange}
+      />
+      {!hideDescription ? (
+        <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
+          <TextArea
+            // aria-readonly={!onDataChange}
+            data-testid={`${dataTestId}-description`}
+            id={`${dataTestId}-description`}
+            name={`${dataTestId}-description`}
+            // value={description}
+            // onChange={(event, value) => onDataChange?.('description', value)}
+            resizeOrientation="vertical"
+          />
+        </FormGroup>
+      ) : null}
+    </>
+  );
+};
+
+export default K8sNameDescriptionField;

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/K8sNameDescriptionField.tsx
@@ -8,6 +8,8 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+import { isMUITheme } from '~/shared/utilities/const';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
 import ResourceNameField from './ResourceNameField';
 
 // TODO: replace with the actual call once we have the endpoint
@@ -55,69 +57,114 @@ const K8sNameDescriptionField: React.FC<K8sNameDescriptionFieldProps> = ({
   const [showK8sField, setShowK8sField] = React.useState(false);
 
   //   const { name, description, k8sName } = data;
+  const nameInput = (
+    <TextInput
+      //   aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-name`}
+      id={`${dataTestId}-name`}
+      name={`${dataTestId}-name`}
+      autoFocus={autoFocusName}
+      isRequired
+      //   value={name}
+      //   onChange={(event, value) => onDataChange?.('name', value)}
+    />
+  );
+
+  const nameFormGroup = (
+    <>
+      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+        <FormFieldset component={nameInput} field="Name" />
+      </FormGroup>
+      {nameHelperText || !showK8sField ? (
+        //  &&
+        // !k8sName.state.immutable
+        <HelperText>
+          {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
+          {!showK8sField && (
+            // !k8sName.state.immutable
+            // &&
+            <>
+              {/* {k8sName.value && (
+                <HelperTextItem>
+                  The resource name will be <b>{k8sName.value}</b>.
+                </HelperTextItem>
+              )} */}
+              <HelperTextItem>
+                <Button
+                  data-testid={`${dataTestId}-editResourceLink`}
+                  variant="link"
+                  isInline
+                  onClick={() => setShowK8sField(true)}
+                >
+                  Edit resource name
+                </Button>{' '}
+                <ResourceNameDefinitionTooltip />
+              </HelperTextItem>
+            </>
+          )}
+        </HelperText>
+      ) : null}
+    </>
+  );
+
+  const descriptionTextInput = (
+    <TextInput
+      // aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-description`}
+      id={`${dataTestId}-description`}
+      name={`${dataTestId}-description`}
+      type="text"
+      // value={description}
+      // onChange={(event, value) => onDataChange?.('description', value)}
+    />
+  );
+
+  const descriptionTextArea = (
+    <TextArea
+      // aria-readonly={!onDataChange}
+      data-testid={`${dataTestId}-description`}
+      id={`${dataTestId}-description`}
+      name={`${dataTestId}-description`}
+      type="text"
+      // value={description}
+      // onChange={(event, value) => onDataChange?.('description', value)}
+      resizeOrientation="vertical"
+    />
+  );
+
+  const descriptionFormGroup = (
+    <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
+      <FormFieldset component={descriptionTextInput} field="Description" />
+    </FormGroup>
+  );
 
   return (
     <>
-      <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
-        <TextInput
-          //   aria-readonly={!onDataChange}
-          data-testid={`${dataTestId}-name`}
-          id={`${dataTestId}-name`}
-          name={`${dataTestId}-name`}
-          autoFocus={autoFocusName}
-          isRequired
-          //   value={name}
-          //   onChange={(event, value) => onDataChange?.('name', value)}
-        />
-        {nameHelperText || !showK8sField ? (
-          //  &&
-          // !k8sName.state.immutable
-          <HelperText>
-            {nameHelperText && <HelperTextItem>{nameHelperText}</HelperTextItem>}
-            {!showK8sField && (
-              // !k8sName.state.immutable
-              // &&
-              <>
-                {/* {k8sName.value && (
-                  <HelperTextItem>
-                    The resource name will be <b>{k8sName.value}</b>.
-                  </HelperTextItem>
-                )} */}
-                <HelperTextItem>
-                  <Button
-                    data-testid={`${dataTestId}-editResourceLink`}
-                    variant="link"
-                    isInline
-                    onClick={() => setShowK8sField(true)}
-                  >
-                    Edit resource name
-                  </Button>{' '}
-                  <ResourceNameDefinitionTooltip />
-                </HelperTextItem>
-              </>
-            )}
-          </HelperText>
-        ) : null}
-      </FormGroup>
+      {isMUITheme() ? (
+        nameFormGroup
+      ) : (
+        <>
+          <FormGroup label={nameLabel} isRequired fieldId={`${dataTestId}-name`}>
+            {nameInput}
+            {nameHelperText}
+          </FormGroup>
+        </>
+      )}
+
       <ResourceNameField
         allowEdit={showK8sField}
         dataTestId={dataTestId}
         // k8sName={k8sName}
         // onDataChange={onDataChange}
       />
-      {!hideDescription ? (
+
+      {!hideDescription && isMUITheme() ? (
+        descriptionFormGroup
+      ) : (
         <FormGroup label={descriptionLabel} fieldId={`${dataTestId}-description`}>
-          <TextArea
-            // aria-readonly={!onDataChange}
-            data-testid={`${dataTestId}-description`}
-            id={`${dataTestId}-description`}
-            name={`${dataTestId}-description`}
-            // value={description}
-            // onChange={(event, value) => onDataChange?.('description', value)}
-            resizeOrientation="vertical"
-          />
+          {descriptionTextArea}
         </FormGroup>
-      ) : null}
+      )}
     </>
   );
 };

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { FormGroup, HelperText, TextInput } from '@patternfly/react-core';
+import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+
+type ResourceNameFieldProps = {
+  allowEdit: boolean;
+  dataTestId: string;
+  //   k8sName: K8sNameDescriptionFieldData['k8sName'];
+  //   onDataChange?: K8sNameDescriptionFieldUpdateFunction;
+};
+
+/** Sub-resource; not for public consumption */
+const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
+  allowEdit,
+  dataTestId,
+  //   k8sName,
+  //   onDataChange,
+}) => {
+  const formGroupProps: React.ComponentProps<typeof FormGroup> = {
+    label: 'Resource name',
+    labelHelp: <ResourceNameDefinitionTooltip />,
+    fieldId: `${dataTestId}-resourceName`,
+  };
+
+  // TODO: Implement this once we have the endpoint.
+
+  //   if (k8sName.state.immutable) {
+  //     return <FormGroup {...formGroupProps}>{k8sName.value}</FormGroup>;
+  //   }
+
+  if (!allowEdit) {
+    return null;
+  }
+
+  // TODO: Implement this once we have the endpoint.
+
+  //   let validated: ValidatedOptions = ValidatedOptions.default;
+  //   if (k8sName.state.invalidLength || k8sName.state.invalidCharacters) {
+  //     validated = ValidatedOptions.error;
+  //   } else if (k8sName.value.length > 0) {
+  //     validated = ValidatedOptions.success;
+  //   }
+
+  //   const usePrefix = k8sName.state.staticPrefix && !!k8sName.state.safePrefix;
+  const textInput = (
+    <TextInput
+      id={`${dataTestId}-resourceName`}
+      data-testid={`${dataTestId}-resourceName`}
+      name={`${dataTestId}-resourceName`}
+      isRequired
+      //   value={
+      //     usePrefix && k8sName.state.safePrefix
+      //       ? k8sName.value.replace(new RegExp(`^${k8sName.state.safePrefix}`), '')
+      //       : k8sName.value
+      //   }
+      //   onChange={(event, value) =>
+      //     onDataChange?.(
+      //       'k8sName',
+      //       usePrefix && k8sName.state.safePrefix ? `${k8sName.state.safePrefix}${value}` : value,
+      //     )
+      //   }
+      //   validated={validated}
+    />
+  );
+  return (
+    <FormGroup {...formGroupProps} isRequired>
+      {/* {usePrefix ? (
+        <InputGroup>
+          <InputGroupText>{k8sName.state.safePrefix}</InputGroupText>
+          <InputGroupItem isFill>{textInput}</InputGroupItem>
+        </InputGroup>
+      ) : ( */}
+      {textInput}
+      {/* )} */}
+      <HelperText>
+        {/* <HelperTextItemMaxLength k8sName={k8sName} />
+        <HelperTextItemValidCharacters k8sName={k8sName} /> */}
+      </HelperText>
+    </FormGroup>
+  );
+};
+
+export default ResourceNameField;

--- a/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/K8sNameDescriptionField/ResourceNameField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { FormGroup, HelperText, TextInput } from '@patternfly/react-core';
-import ResourceNameDefinitionTooltip from '~/concepts/k8s/ResourceNameDefinitionTootip';
+import { FormGroup, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
+import FormFieldset from '~/app/pages/modelRegistry/screens/components/FormFieldset';
+import { isMUITheme } from '~/shared/utilities/const';
 
 type ResourceNameFieldProps = {
   allowEdit: boolean;
@@ -16,12 +17,6 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
   //   k8sName,
   //   onDataChange,
 }) => {
-  const formGroupProps: React.ComponentProps<typeof FormGroup> = {
-    label: 'Resource name',
-    labelHelp: <ResourceNameDefinitionTooltip />,
-    fieldId: `${dataTestId}-resourceName`,
-  };
-
   // TODO: Implement this once we have the endpoint.
 
   //   if (k8sName.state.immutable) {
@@ -47,6 +42,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
       id={`${dataTestId}-resourceName`}
       data-testid={`${dataTestId}-resourceName`}
       name={`${dataTestId}-resourceName`}
+      type="text"
       isRequired
       //   value={
       //     usePrefix && k8sName.state.safePrefix
@@ -62,22 +58,47 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
       //   validated={validated}
     />
   );
-  return (
-    <FormGroup {...formGroupProps} isRequired>
-      {/* {usePrefix ? (
-        <InputGroup>
-          <InputGroupText>{k8sName.state.safePrefix}</InputGroupText>
-          <InputGroupItem isFill>{textInput}</InputGroupItem>
-        </InputGroup>
-      ) : ( */}
-      {textInput}
-      {/* )} */}
+
+  const resourceNameFormGroup = (
+    <>
+      <FormGroup
+        label="Resource name"
+        className="resource-name"
+        isRequired
+        fieldId={`${dataTestId}-resource-name`}
+      >
+        <FormFieldset component={textInput} field="Host" />
+      </FormGroup>
       <HelperText>
+        <HelperTextItem>
+          The resource name is used to identify your resource, and is generated based on the name
+          you enter. The resource name cannot be edited after creation.
+        </HelperTextItem>
         {/* <HelperTextItemMaxLength k8sName={k8sName} />
-        <HelperTextItemValidCharacters k8sName={k8sName} /> */}
+         <HelperTextItemValidCharacters k8sName={k8sName} /> */}
       </HelperText>
-    </FormGroup>
+    </>
   );
+
+  // TODO: Implement this once we have the endpoint.
+  // return (
+  //   <FormGroup {...formGroupProps} isRequired>
+  //     {usePrefix ? (
+  //       <InputGroup>
+  //         <InputGroupText>{k8sName.state.safePrefix}</InputGroupText>
+  //         <InputGroupItem isFill>{textInput}</InputGroupItem>
+  //       </InputGroup>
+  //     ) : (
+  //       { textInput }
+  //     )}
+  //     <HelperText>
+  //       <HelperTextItemMaxLength k8sName={k8sName} />
+  //       <HelperTextItemValidCharacters k8sName={k8sName} />
+  //     </HelperText>
+  //   </FormGroup>
+  // );
+
+  return isMUITheme() ? resourceNameFormGroup : textInput;
 };
 
 export default ResourceNameField;

--- a/clients/ui/frontend/src/concepts/k8s/ResourceNameDefinitionTootip.tsx
+++ b/clients/ui/frontend/src/concepts/k8s/ResourceNameDefinitionTootip.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Stack, StackItem } from '@patternfly/react-core';
+import FieldGroupHelpLabelIcon from '~/shared/components/FieldGroupHelpLabelIcon';
+
+const ResourceNameDefinitionTooltip: React.FC = () => (
+  <FieldGroupHelpLabelIcon
+    content={
+      <Stack hasGutter>
+        <StackItem>
+          The resource name is used to identify your resource in OpenShift, and is generated based
+          on the name you enter.
+        </StackItem>
+        <StackItem>The resource name cannot be edited after creation.</StackItem>
+      </Stack>
+    }
+  />
+);
+
+export default ResourceNameDefinitionTooltip;

--- a/clients/ui/frontend/src/shared/components/FieldGroupHelpLabelIcon.tsx
+++ b/clients/ui/frontend/src/shared/components/FieldGroupHelpLabelIcon.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import DashboardPopupIconButton from '~/shared/components/dashboard/DashboardPopupIconButton';
+
+type FieldGroupHelpLabelIconProps = {
+  content: React.ComponentProps<typeof Popover>['bodyContent'];
+};
+
+const FieldGroupHelpLabelIcon: React.FC<FieldGroupHelpLabelIconProps> = ({ content }) => (
+  <Popover bodyContent={content}>
+    <DashboardPopupIconButton icon={<OutlinedQuestionCircleIcon />} aria-label="More info" />
+  </Popover>
+);
+
+export default FieldGroupHelpLabelIcon;

--- a/clients/ui/frontend/src/shared/style/MUI-theme.scss
+++ b/clients/ui/frontend/src/shared/style/MUI-theme.scss
@@ -2,7 +2,7 @@
   // Alert
   --mui-alert--BoxShadow: none;
   --mui-alert-warning-text: #663c00;
-  --mui-alert-warning-font-weight: 400;
+  --mui-alert-warning-FontWeight: 400;
   --mui-alert--PaddingBlockStart: 6px;
   --mui-alert--PaddingBlockEnd: 6px;
   --mui-alert--PaddingInlineStart: 16px;
@@ -14,7 +14,7 @@
   --mui-alert__icon--FontSize: 22px;
 
   // Button
-  --mui-button-font-weight: 500;
+  --mui-button-FontWeight: 500;
   --mui-button--hover--BorderWidth: 1px;
   --mui-button--PaddingBlockStart: 6px;
   --mui-button--PaddingBlockEnd: 6px;
@@ -22,6 +22,9 @@
   --mui-button--PaddingInlineEnd: 16px;
   --mui-button--LineHeight: 1.75;
   --mui-link-underlineColor: rgba(33, 150, 243, 0.4);
+
+  // Helper text
+  --mui-helper-text__item--FontWeight: 400;
 
   // Menu item
   --mui-menu__item--PaddingBlockStart: 6px;
@@ -121,7 +124,7 @@
     --pf-t--global--text--color--status--warning--default
   );
   --pf-v6-c-alert__icon--MarginInlineEnd: var(--mui-alert__icon--MarginInlineEnd);
-  --pf-v6-c-alert__title--FontWeight: var(--mui-alert-warning-font-weight);
+  --pf-v6-c-alert__title--FontWeight: var(--mui-alert-warning-FontWeight);
   --pf-v6-c-alert__icon--MarginBlockStart: var(--mui-alert__icon--MarginBlockStart);
   --pf-v6-c-alert__icon--FontSize: var(--mui-alert__icon--FontSize);
   --pf-v6-c-alert--BoxShadow: var(--mui-alert--BoxShadow);
@@ -144,7 +147,7 @@
 }
 
 .mui-theme .pf-v6-c-button {
-  --pf-v6-c-button--FontWeight: var(--mui-button-font-weight);
+  --pf-v6-c-button--FontWeight: var(--mui-button-FontWeight);
   --pf-v6-c-button--PaddingBlockStart: var(--mui-button--PaddingBlockStart);
   --pf-v6-c-button--PaddingBlockEnd: var(--mui-button--PaddingBlockEnd);
   --pf-v6-c-button--PaddingInlineStart: var(--mui-button--PaddingInlineStart);
@@ -179,6 +182,10 @@
   align-content: center;
 }
 
+.mui-theme .pf-v6-c-form {
+  --pf-v6-c-form--GridGap: none;
+}
+
 .mui-theme .pf-v6-c-form__group {
   position: relative;
 }
@@ -193,8 +200,16 @@
   color: var(--mui-palette-text-disabled);
 }
 
+.mui-theme .pf-v6-c-form__group.form-group-error .pf-v6-c-form__label {
+  color: var(--mui-palette-error-main);
+}
+
 .mui-theme .pf-v6-c-form__helper-text.path-helper-text {
   margin-inline-start: var(--pf-t--global--spacer--lg);
+}
+
+.mui-theme .pf-v6-c-helper-text .pf-v6-c-helper-text__item-icon {
+  display: none;
 }
 
 .mui-theme .pf-v6-c-form__section-title {
@@ -227,6 +242,8 @@
 .mui-theme .pf-v6-c-form-control {
   --pf-v6-c-form-control--m-disabled--BackgroundColor: var(--mui-palette-common-white);
   --pf-v6-c-form-control--m-disabled--Color: var(--mui-palette-text-disabled);
+  --pf-v6-c-form-control--m-error--after--BorderColor: var(--mui-palette-error-main);
+  --pf-v6-c-form-control--m-error--hover--after--BorderColor: var(--mui-palette-error-main);
 }
 
 .mui-theme .pf-v6-c-form-control {
@@ -311,8 +328,24 @@
   border-color: black;
 }
 
-.form-fieldset-wrapper:hover span.pf-v6-c-form-control.pf-m-disabled ~ .form-fieldset {
+.form-fieldset-wrapper:focus-within span.pf-v6-c-form-control.pf-m-disabled ~ .form-fieldset {
   border-color: rgba(0, 0, 0, 0.23);
+}
+
+.form-fieldset-wrapper span.pf-v6-c-form-control.pf-m-error ~ .form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.form-fieldset-wrapper .pf-v6-c-input-group span.pf-v6-c-form-control .pf-m-error ~ .form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.form-fieldset-wrapper .pf-v6-c-input-group__item button {
+  // Aligns EyeIcon in password input
+  --pf-v6-c-button--PaddingBlockStart: var(--mui-spacing-16px);
+  --pf-v6-c-button--PaddingBlockEnd: var(--mui-spacing-16px);
+  --pf-v6-c-button--BorderColor: var(--mui-palette-common-white);
+  --pf-v6-c-button--BorderRadius: 50%;
 }
 
 .form-fieldset-wrapper:focus-within .form-fieldset {
@@ -410,10 +443,34 @@
 
 .pf-v6-c-form__group:focus-within .pf-v6-c-form-control {
   --pf-v6-c-form-control--after--BorderWidth: 2px;
-  --pf-v6-c-form-control--after--BorderColor: var(--mui-palette-primary-main);
 }
 
-.pf-v6-c-form__group:focus-within .pf-v6-c-form__label {
+.pf-v6-c-form-control.pf-m-error {
+  --pf-v6-c-form-control--after--BorderColor: var(--mui-palette-error-main);
+}
+
+.mui-theme .pf-v6-c-form-control__utilities {
+  display: none;
+}
+
+.pf-v6-c-helper-text__item.pf-m-error {
+  --pf-v6-c-helper-text__item-text--Color: var(--mui-palette-error-main);
+  --pf-v6-c-helper-text__item-text--FontWeight: var(--mui-helper-text__item--FontWeight);
+  margin-left: 14px;
+  margin-top: 3px;
+}
+
+.pf-v6-c-form__group.pf-m-error .pf-v6-c-form__label {
+  // Using CSS property here since --pf-v6-c-form__label--Color does not exist.
+
+  color: var(--mui-palette-error-main);
+}
+
+.mui-theme .pf-v6-c-form__group.pf-m-error fieldset.form-fieldset {
+  border-color: var(--mui-palette-error-main);
+}
+
+.pf-v6-c-form__group:not(.pf-m-error):focus-within .pf-v6-c-form__label {
   // Using CSS property here since --pf-v6-c-form__label--Color does not exist.
 
   /* Change color of the label when the input is focused */
@@ -462,13 +519,13 @@
 
   border-radius: var(--mui-shape-borderRadius);
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
 }
 
 .mui-theme .pf-v6-c-menu-toggle__button {
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   letter-spacing: 0.02857em;
   align-self: stretch;
 }
@@ -639,7 +696,7 @@
   --pf-v6-c-table--cell--first-last-child--PaddingInline: var(
     --mui-table--cell--first-last-child--PaddingInline
   );
-  --pf-v6-c-table__thead--cell--FontWeight: var(--mui-button-font-weight);
+  --pf-v6-c-table__thead--cell--FontWeight: var(--mui-button-FontWeight);
   --pf-v6-c-table__thead--cell--FontSize: var(--mui-table__thead--cell--FontSize);
   --pf-v6-c-table__tr--BorderBlockEndColor: var(--mui-palette-grey-300);
   --pf-v6-c-table__sort-indicator--MarginInlineStart: var(
@@ -716,7 +773,7 @@
 
 .mui-theme .pf-v6-c-tabs__link {
   text-transform: var(--mui-text-transform);
-  font-weight: var(--mui-button-font-weight);
+  font-weight: var(--mui-button-FontWeight);
   line-height: var(--mui-button-line-height);
   letter-spacing: 0.02857em;
 }
@@ -829,7 +886,6 @@
   /* Position sidebar above the masthead */
 }
 
-
 /* Hide Masthead Toggle by default */
 .mui-theme .pf-v6-c-masthead__toggle {
   display: none;
@@ -847,9 +903,9 @@
   }
 }
 
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-container,
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__drawer,
-.pf-v6-c-page__sidebar:not(.pf-m-collapsed)+.pf-v6-c-page__main-breadcrumb {
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__main-container,
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__drawer,
+.mui-theme .pf-v6-c-page__sidebar:not(.pf-m-collapsed) + .pf-v6-c-page__main-breadcrumb {
   --pf-v6-c-page__main-container--MarginInlineStart: calc(-2 * var(--mui-spacing-16px));
   --pf-v6-c-page__main-section--PaddingInlineStart: none;
   --pf-v6-c-page__main-section--PaddingInlineEnd: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

This PR is focused on theming the validated form inputs in the "Create Model Registry" form in order to align with the validated form inputs from MUI. Some DOM structure changes and refactoring are required to adhere to previous theming conventions with the form fields.

Before:
<img width="500" alt="Screenshot 2025-03-07 at 4 34 05 PM" src="https://github.com/user-attachments/assets/bb459086-d3a6-4886-a6e2-d3c4cfd54910" />

After:
<img width="500" alt="Screenshot 2025-03-07 at 4 33 10 PM" src="https://github.com/user-attachments/assets/e21e7dc9-d956-4770-881c-8acb5c17d230" />

Note: There are certain components within the "Create Model Registry" Modal that are exclusive to this form. 

I.e., the <InputGroup> within the password component requires a custom solution to ensure it aligns with text field validation.
The description field also requires similar adjustments to align with the validation and theming.

This is in progress will be addressed in following commits.
